### PR TITLE
Fix MIDI message sending for touch behavior

### DIFF
--- a/Motor-Controller/main.cpp
+++ b/Motor-Controller/main.cpp
@@ -271,7 +271,7 @@ void sendMIDIMessages(bool touched) {
     // Touch
     static bool prevTouched = false; // Whether the knob is being touched
     if (touched != prevTouched) {
-        const MIDIAddress addr = MCU::FADER_TOUCH_1 + Idx;
+        MIDIAddress addr(MCU::FADER_TOUCH_1, Channel(Idx)); // Send note on/off on correct channel
         touched ? midi.sendNoteOn(addr, 127) : midi.sendNoteOff(addr, 127);
         prevTouched = touched;
     }


### PR DESCRIPTION
This change modifies the sendMIDIMessages function to send Note On and Note Off messages on different MIDI channels based on the fader that is being touched

Previously, all Note On and Note Off messages were sent on the default channel (channel 1) because the MIDIAddress for these messages was created with only the note number (MCU::FADER_TOUCH_1 + Idx), and no channel was specified. 

In this change, a MIDIAddress object is created with both the note number and the channel. The channel is set to the fader index (Idx), which means that each fader will send messages on the corresponding channel.